### PR TITLE
Workaround filter_input bug

### DIFF
--- a/GitHub_WebHook.php
+++ b/GitHub_WebHook.php
@@ -24,6 +24,13 @@
 			{
 				throw new Exception( 'Missing event header.' );
 			}
+
+			$this->EventType = $this->GetEventHeaderName();
+
+			if ( preg_match( '/^[a-z_]+$/', $this->EventType ) !== 1 )
+			{
+				throw new Exception( 'Invalid event header.' );
+			}
 			
 			if( !array_key_exists( 'REQUEST_METHOD', $_SERVER ) || $_SERVER[ 'REQUEST_METHOD' ] !== 'POST' )
 			{
@@ -34,9 +41,7 @@
 			{
 				throw new Exception( 'Missing content type.' );
 			}
-			
-			$this->EventType = filter_input( INPUT_SERVER, $this->GetEventHeaderName(), FILTER_SANITIZE_STRING );
-			
+
 			$ContentType = $_SERVER[ 'CONTENT_TYPE' ];
 			
 			if( $ContentType === 'application/x-www-form-urlencoded' )


### PR DESCRIPTION
filter_input sometimes returns NULL for INPUT_SERVER even though the value is
set and accessible through $_SERVER directly. This is apparently a long standing
bug. The work around is to use one of the other filter_* function on the value
retrieved from $_SERVER directly.

    $safe_key = filter_var($_SERVER['key'], FILTER_SANITIZE_STRING);

References:
* https://bugs.php.net/bug.php?id=49184
* http://php.net/manual/en/function.filter-input.php#77307
* http://stackoverflow.com/questions/25232975/php-filter-inputinput-server-request-method-returns-null